### PR TITLE
fix: Implement robust opponent HP bar

### DIFF
--- a/DuskFiles/ClientSource/Dusk.java
+++ b/DuskFiles/ClientSource/Dusk.java
@@ -47,9 +47,7 @@ public class Dusk implements Runnable,MouseListener,KeyListener,ComponentListene
         LocX=0,
         LocY=0,
         inthp,
-        hp2,
         intmaxhp,
-        maxhp2,
         intsp,
         intmaxsp,
         range=1;
@@ -1386,31 +1384,37 @@ public class Dusk implements Runnable,MouseListener,KeyListener,ComponentListene
 					frmBattle.txtEdit.append(strStore+"\n");
                                         break;
 				}
-                                case (34): //Zach's try on adding enemy hp bar. Don't work :( needs a update method somewhere.
-				{
+                                case (34):
+                                {
                                     try {
-                                    // Extract HP
+                                        long opponentID = Long.parseLong(stmIn.readLine());
                                         String HpData = stmIn.readLine();
                                            if (HpData == null) {
                                         System.err.println("Input stream ended before the expected line was found.");
                                         } else {
-                                        // Now it is safe to process the string
                                         String[] hpValues = HpData.trim().split(" ");
+                                        int newHp = Integer.parseInt(hpValues[0]);
+                                        int newMaxHp = Integer.parseInt(hpValues[1]);
 
-                                        // Convert to integers
-                                        hp2 = Integer.parseInt(hpValues[0]);
-                                        maxhp2 = Integer.parseInt(hpValues[1]);
+                                        // Find the entity and update its HP
+                                        synchronized(vctEntities) {
+                                            for (int i = 0; i < vctEntities.size(); i++) {
+                                                Entity ent = (Entity)vctEntities.elementAt(i);
+                                                if (ent.ID == opponentID) {
+                                                    ent.hp = newHp;
+                                                    ent.maxhp = newMaxHp;
+                                                    break;
+                                                }
+                                            }
                                         }
-                                        } catch (NumberFormatException e) {
-                                        // This exception is thrown if the string parts are not valid integers.
-                                        System.err.println("Failed to parse HP values: " + e.getMessage());
-    
-                                        } catch (ArrayIndexOutOfBoundsException e) {
-                                        // This exception is thrown if the split string doesn't have at least two parts.
-                                        System.err.println("Received data is not in the expected format (e.g., 'HP MaxHP')");
                                         }
+                                    } catch (Exception e) {
+                                        System.err.println("Error updating opponent HP: " + e.getMessage());
+                                    }
+                                    update();
+                                    paint();
                                     break;
-				}
+                                }
 				default:  //if an incoming byte doesn't fit the switch
 				{
 					System.err.println("Lost incoming byte: " + incoming);	
@@ -1935,8 +1939,9 @@ public class Dusk implements Runnable,MouseListener,KeyListener,ComponentListene
                                         gD.fillRect((int)(x*intImageSize), (int)(y*intImageSize) - 65, (int) HPBarValue, 10);
                         }else if (entStore.intFlag == 2)
 			{
-                            	double CurrentHPWidth2 = (double) intImageSize / maxhp2;
-                                double HPBarValue2 = CurrentHPWidth2 * hp2;                            
+                            if (entStore.maxhp > 0) {
+				double CurrentHPWidth2 = (double) intImageSize / entStore.maxhp;
+                                double HPBarValue2 = CurrentHPWidth2 * entStore.hp;
 				gD.setColor(Color.red);
 				gD.drawRoundRect((int)(x*intImageSize),(int)(y*intImageSize),
 							intImageSize,intImageSize,intImageSize/3,intImageSize/3);
@@ -1944,7 +1949,8 @@ public class Dusk implements Runnable,MouseListener,KeyListener,ComponentListene
                                         gD.fillRect((int)(x*intImageSize)- 1, (int)(y*intImageSize) - 66, (int)(intImageSize) + 2, 12);
 
                                         gD.setColor(new Color(255, 0, 30));
-                                        gD.fillRect((int)(x*intImageSize), (int)(y*intImageSize) - 65, (int) HPBarValue2, 10);			
+                                        gD.fillRect((int)(x*intImageSize), (int)(y*intImageSize) - 65, (int) HPBarValue2, 10);
+                            }
                         }
 		}
 

--- a/DuskFiles/ClientSource/Entity.java
+++ b/DuskFiles/ClientSource/Entity.java
@@ -31,6 +31,8 @@ public class Entity
         1 ally
         2 enemy
         */
+    int hp,
+        maxhp;
     long ID;
     Entity entNext=null;
     
@@ -43,5 +45,7 @@ public class Entity
     	intImage = inImage;
     	intStep = inStep;
     	intType = inintType;
+        hp = 0;
+        maxhp = 0;
     }
 }

--- a/DuskFiles/DuskServerSource/Battle.java
+++ b/DuskFiles/DuskServerSource/Battle.java
@@ -803,6 +803,12 @@ public class Battle
            			strStore = attack(thnStore,thnTarget, range, strStore);
 				}
 				strStore += ".";
+				for (int j=0; j<vctSide1.size(); j++) {
+					LivingThing player = (LivingThing)vctSide1.elementAt(j);
+					if (player.isPlayer()) {
+						player.updateOpponentHP(thnTarget);
+					}
+				}
 			}
 			chatMessage("\t"+strStore);
 		}
@@ -914,6 +920,12 @@ public class Battle
            			strStore = attack(thnStore,thnTarget, range, strStore);
 				}
 				strStore += ".";
+				for (int j=0; j<vctSide2.size(); j++) {
+					LivingThing player = (LivingThing)vctSide2.elementAt(j);
+					if (player.isPlayer()) {
+						player.updateOpponentHP(thnTarget);
+					}
+				}
 			}
 			chatMessage("\t"+strStore);
 		}

--- a/DuskFiles/DuskServerSource/LivingThing.java
+++ b/DuskFiles/DuskServerSource/LivingThing.java
@@ -2086,6 +2086,17 @@ public class LivingThing extends DuskObject implements Runnable
 		}
 	}
 	
+	public void updateOpponentHP(LivingThing opponent)
+	{
+	    if (isPlayer() && blnWorking && !blnIsClosing)
+	    {
+	        String strResult = "" + (char)34;
+	        strResult += opponent.ID + "\n";
+	        strResult += opponent.hp + " " + opponent.maxhp + "\n";
+	        send(strResult);
+	    }
+	}
+
 	public void updateMap()
 	{
 		//update map:


### PR DESCRIPTION
This commit provides a complete and robust fix for the opponent HP bar functionality. The previous implementation was flawed as it used global variables on the client side to store opponent HP, which did not work correctly for multiple opponents.

This commit introduces the following changes:
- The `Entity.java` class on the client side now has `hp` and `maxhp` fields to store health information for each individual entity.
- The server-side `LivingThing.java` has been updated to send the unique ID of the opponent along with their health data.
- The `Battle.java` class on the server now calls the new `updateOpponentHP` method after each attack to ensure timely updates.
- The client-side `Dusk.java` has been refactored to handle the new per-entity HP data, removing the old global variables and updating the rendering logic to use the entity's own health fields.